### PR TITLE
BUG Fixed blank option in Calender->DefaultView

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -8,7 +8,7 @@ class Calendar extends Page {
 		'RSSTitle' => 'Varchar(255)',
 		'DefaultFutureMonths' => 'Int',
 		'EventsPerPage' => 'Int',
-		'DefaultView' => "Enum('today,week,,month,weekend,upcoming','upcoming')"
+		'DefaultView' => "Enum('today,week,month,weekend,upcoming','upcoming')"
 	);
 	
 	private static $has_many = array (


### PR DESCRIPTION
There seems to be a blank option in Calender::$db DefaultView that dev/build doesn't seem to correctly handle (it keeps regenerating the field each build).

Is this a hassle to remove this blank option?
