### PR TITLE
Include EndDate in Recurrence

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -341,7 +341,7 @@ class Calendar extends Page {
 					// check the end date
 					if($recurring_event_datetime->EndDate) {
 						$end_stamp = strtotime($recurring_event_datetime->EndDate);
-						if($end_stamp > 0 && $end_stamp <= $date_counter->get()) {							
+						if($end_stamp > 0 && $end_stamp < $date_counter->get()) {							
 							break;
 						}
 					}


### PR DESCRIPTION
Most other calendar systems include the EndDate as the last day the
recurrence should occur, not the first date it shouldn't.  A simple
change from <= to < fixes this.
