### PR TITLE
Recurrence Exceptions don't work

### DIFF
--- a/code/CalendarEvent.php
+++ b/code/CalendarEvent.php
@@ -101,14 +101,14 @@ class CalendarEvent extends Page
 				new DropdownField('MonthlyDayOfWeek','', DataList::create("RecurringDayOfWeek")->map("Value", "Title")),
 				new LabelField( $name = "ofthemonth", $title = _t("CalendarEvent.OFTHEMONTH"," of the month."))
 		));
-		// $f->addFieldToTab("Root.$recursion",
-		// 	GridField::create(
-		// 		"Exceptions",
-		// 		_t('CalendarEvent.ANYEXCEPTIONS','Any exceptions to this pattern? Add the dates below.'),
-		// 		$this->Exceptions(),
-		// 		GridFieldConfig_RecordEditor::create()
-		// 	)
-		// ));
+		$f->addFieldToTab("Root.$recursion",
+		 	GridField::create(
+		 		"Exceptions",
+		 		_t('CalendarEvent.ANYEXCEPTIONS','Any exceptions to this pattern? Add the dates below.'),
+		 		$this->Exceptions(),
+		 		GridFieldConfig_RecordEditor::create()
+		 	)
+		);
 		$dailyInterval->addExtraClass('dailyinterval');
 		$weeklyInterval->addExtraClass('weeklyinterval');
 		$monthlyInterval->addExtraClass('monthlyinterval');

--- a/code/RecurringException.php
+++ b/code/RecurringException.php
@@ -14,5 +14,27 @@ class RecurringException extends DataObject
 
 
 	static $default_sort = "ExceptionDate ASC";
-	
+
+        public function getCMSFields() {
+                DateField::set_default_config('showcalendar', true);
+                $f = new FieldList(
+                        new DateField('ExceptionDate',_t('CalendarDateTime.EXCEPTIONDATE','Exception Date'))
+                );
+
+                $this->extend('updateCMSFields', $f);
+
+                return $f;
+        }
+
+       public function summaryFields() {
+                return array (
+                        'FormattedExceptionDate' => _t('Calendar.EXCEPTIONDATE','Exception date')
+                );
+        }
+
+        public function getFormattedExceptionDate() {
+           if(!$this->ExceptionDate) return "--";
+           return CalendarUtil::get_date_format() == "mdy" ? $this->obj('ExceptionDate')->Format('m-d-Y') : $this->obj('ExceptionDate')->Format('d-m-Y');
+        }
+
 }


### PR DESCRIPTION
Uncommented Recurrence Exceptions in Calendar Event, and cleaned up for
usability.
1. Show dates instead of IDs in Gridfield
2. Use a calendar to select Exception Date
