### PR TITLE
Fix first day in calendar error / number of rows in calendar.

### DIFF
--- a/javascript/calendar_widget.js
+++ b/javascript/calendar_widget.js
@@ -25,6 +25,7 @@
 			this.firstDay = new Date(this.year, this.month, 1);
 			this.startingDay = this.firstDay.getDay();
 			if($.CalendarWidget.settings.startOnMonday) {
+				if(this.startingDay === 0) this.startingDay=6; else 
 				this.startingDay--;
 			}			
 			this.monthLength = this.settings.calDaysInMonth[this.month];
@@ -162,7 +163,7 @@
 
 			var cell = 1;
 			var empties = 0;
-			var row_count = Math.ceil(this.monthLength/7);
+			var row_count = Math.ceil((this.monthLength+this.startingDay)/7);
 			for (var i = 0; i < row_count; i++) {
 				for (var j = 0; j <= 6; j++) {
 					date = "";


### PR DESCRIPTION
When first day of month is sunday and option -use Monday as first day is set in calendar widget the month start form Monday. Problem when some month need more that 5 rows to show all days.
