### PR TITLE
Set monday as the first day in calendarwidget header

### DIFF
--- a/javascript/calendar_widget.js
+++ b/javascript/calendar_widget.js
@@ -152,9 +152,13 @@
 			html += '</thead>';
 			html += '<tbody>';
 			html += '<tr class="calendar-header">';
-			for(var i = 0; i <= 6; i++ ){
+			for(var i = 1; i <= 7; i++ ){
 				html += '<td class="calendar-header-day">';
-				html += this.settings.calDaysLabels[i];
+				if (i != 7 ) {
+					html += this.settings.calDaysLabels[i];
+				} else {
+					html += this.settings.calDaysLabels[0];
+				}
 				html += '</td>';
 			}
 			html += "<td>&nbsp;</td>"


### PR DESCRIPTION
When applying pull #24 to use monday for firstday of week, the header loop is still adding sunday as the first day, this is a quick and dirty fix.
