### PR TITLE
Fixed issue where start and end filter are not applied in 3.1

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -222,11 +222,11 @@ class Calendar extends Page {
 			->innerJoin("SiteTree", "\"SiteTree\".\"ID\" = \"{$eventClass}\".\"ID\"");
 
 		if($start) {
-			$list->filter("StartDate:GreaterThan:Not", $start);
+			$list = $list->filter("StartDate:GreaterThan:Not", $start);
 		}
 
 		if($end) {
-			$list->filter("EndDate:LessThan:Not", $end);
+			$list = $list->filter("EndDate:LessThan:Not", $end);
 		}
 
 		if($filter) {


### PR DESCRIPTION
Fixed issue where start and end filter are not applied in 3.1 caused my changes to how DataList's are mutated in 3.1.
