### PR TITLE
Recurring events for multiple date times

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -294,12 +294,22 @@ class Calendar extends Page {
 			$relation = $recurring_event->getReverseAssociation($this->getDateTimeClass());
 			if(!$relation) continue;
 
-			foreach ($recurring_event->$relation() as $recurring_event_datetime) {
+            $recurring_event_datetimes = $recurring_event->$relation()->filter(array(
+                'StartDate:LessThanOrEqual' => $end->date(),
+                'EndDate:GreaterThanOrEqual' => $date_counter->date(),
+            ));
+
+            foreach ($recurring_event_datetimes as $recurring_event_datetime) {
+                $date_counter = sfDate::getInstance($start_date);
+                $start = sfDate::getInstance($recurring_event_datetime->StartDate);
+                if ($start->get() > $date_counter->get()) {
+                    $date_counter = $start;
+                }
 				while($date_counter->get() <= $end->get()){
 					// check the end date
 					if($recurring_event_datetime->EndDate) {
 						$end_stamp = strtotime($recurring_event_datetime->EndDate);
-						if($end_stamp > 0 && $end_stamp < $date_counter->get()) {							
+						if($end_stamp > 0 && $end_stamp < $date_counter->get()) {
 							break;
 						}
 					}


### PR DESCRIPTION
When adding multiple series of date/times on a recurring event it would not generate the appropriate dates as it only looked at the first instance of CalendarDateTime found. I have now corrected to foreach over all CalendarDateTimes found
