### PR TITLE
HasEvent mark next/prev months

### DIFF
--- a/javascript/calendar_widget_init.js
+++ b/javascript/calendar_widget_init.js
@@ -62,12 +62,16 @@ $('.calendar-widget').each(function() {
 
 		onMonthChange: function(month, year, calendar) {
 			var json;
-			m = calendar.pad(month);		
+			m = calendar.pad(month);
+			prev_month = calendar.pad(month+1);
+			next_month = calendar.pad(month-1);			
 			if(!loaded_months[year+m]) {
 				loadMonthJson(m, year);
 			}
 			json = loaded_months[year+m];
 			applyMonthJson(m, year);
+			applyMonthJson(prev_month, prev_year);
+			applyMonthJson(next_month, next_year);
 			setSelection(calendar);
 		},
 


### PR DESCRIPTION
For consistence mark the next and prev month calendar days (visible in current month) with events. Now it is done only only during the initiation of calendar widget, the reason of modification is to have the same functionality when change in widget the view to next/prev month. Also this change can be applied with change in css file and adding another color for days .out-of-month.hasEvent for example add line like that 
.calendar-widget-table tbody .out-of-month.hasEvent {background: #33CC99;color:#fff;}
