### PR TITLE
Call to extend() in index for controller

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -562,6 +562,7 @@ class Calendar_Controller extends Page_Controller {
 	}
 
 	public function index(SS_HTTPRequest $r) {
+		$this->extend('index',$r);
 		switch($this->DefaultView) {
 			case "month":
 				return $this->redirect($this->Link('show/month'));


### PR DESCRIPTION
UncleCheese, can you add an extend to the top of the index of Calendar_Controller so the redirects can be overruled? (I'm using a customised calendar which I want to redirect to $this->redirect($this->Link('month')); instead of $this->redirect($this->Link('show/month'));)
