### PR TITLE
changed action 'view' to 'show'

### DIFF
--- a/javascript/calendar_core.js
+++ b/javascript/calendar_core.js
@@ -7,7 +7,7 @@ function navigateToDate(date)
 	else 
 		query_string = "";
 	parts = loc.split(current_url_segment);
-	document.location = controller_url_segment+"view/"+date+query_string
+	document.location = controller_url_segment+"show/"+date+query_string
 }
 
 function zeroPad(num) {


### PR DESCRIPTION
On the month jumper i encountered a problem when changing the date, the url would lead to a non existing page.
In Calender.php i saw that 'show' was a allowed action so i presumed changing 'view' to 'show' would fix the issue.
