### PR TITLE
Wrap getCMSField in beforeUpdateCMSField

### DIFF
--- a/code/CalendarEvent.php
+++ b/code/CalendarEvent.php
@@ -32,7 +32,7 @@ class CalendarEvent extends Page {
 	
 	private static $can_be_root = false;
 
-	public function getCMSFields() {=
+	public function getCMSFields() {
 		
 		$self = $this;
 		

--- a/code/CalendarEvent.php
+++ b/code/CalendarEvent.php
@@ -34,87 +34,96 @@ class CalendarEvent extends Page {
 
 	public function getCMSFields() {
 		Requirements::javascript('event_calendar/javascript/calendar_cms.js');
-		$f = parent::getCMSFields();
-		$dt = _t('CalendarEvent.DATESANDTIMES','Dates and Times');
-		$recursion = _t('CalendarEvent.RECURSION','Recursion');
-		$f->addFieldToTab("Root.$dt",
-			GridField::create(
-				"DateTimes",
-				_t('Calendar.DATETIMEDESCRIPTION','Add dates for this event'),
-				$this->DateTimes(),
-				GridFieldConfig_RecordEditor::create()
-			)
-		);
-
-		$f->addFieldsToTab("Root.$recursion", array(
-			new CheckboxField('Recursion',_t('CalendarEvent.REPEATEVENT','Repeat this event')),			
-			new OptionsetField(
-				'CustomRecursionType',
-				_t('CalendarEvent.DESCRIBEINTERVAL','Describe the interval at which this event recurs.'),
-				array (
-					'1' => _t('CalendarEvent.DAILY','Daily'),
-					'2' => _t('CalendarEvent.WEEKLY','Weekly'),
-					'3' => _t('CalendarEvent.MONTHLY','Monthly')
+		
+		$self = $this;
+		
+		$this->beforeUpdateCMSFields(function($f) use ($self) {
+			Requirements::javascript('event_calendar/javascript/calendar_cms.js');
+			
+			$dt = _t('CalendarEvent.DATESANDTIMES','Dates and Times');
+			$recursion = _t('CalendarEvent.RECURSION','Recursion');
+		
+			$f->addFieldToTab("Root.$dt",
+				GridField::create(
+					"DateTimes",
+					_t('Calendar.DATETIMEDESCRIPTION','Add dates for this event'),
+					$self->DateTimes(),
+					GridFieldConfig_RecordEditor::create()
 				)
-			)
-		));
-		
-		$f->addFieldToTab("Root.$recursion", $dailyInterval = new FieldGroup(
-					new LabelField($name = "every1", $title = _t("CalendarEvent.EVERY","Every ")),
-					new DropdownField('DailyInterval', '', array_combine(range(1,10), range(1,10))),
-					new LabelField($name = "days",$title = _t("CalendarEvent.DAYS"," day(s)"))
-		));			
-		
-		$f->addFieldToTab("Root.$recursion", $weeklyInterval = new FieldGroup(
-					new LabelField($name = "every2", $title = _t("CalendarEvent.EVERY","Every ")),
-					new DropdownField('WeeklyInterval', '', array_combine(range(1,10), range(1,10))),
-					new LabelField($name = "weeks", $title = _t("CalendarEvent.WEEKS", " weeks"))
-		));
-		
-		$f->addFieldToTab("Root.$recursion", new CheckboxSetField(
-				'RecurringDaysOfWeek', 
-				_t('CalendarEvent.ONFOLLOWINGDAYS','On the following day(s)...'), 
-				DataList::create("RecurringDayOfWeek")->map("ID", "Title")
-		));
-		
-		$f->addFieldToTab("Root.$recursion", $monthlyInterval = new FieldGroup(
-				new LabelField($name="every3", $title = _t("CalendarEvent.EVERY","Every ")),
-				new DropdownField('MonthlyInterval', '', array_combine(range(1,10), range(1,10))),
-				new LabelField($name = "months", $title = _t("CalendarEvent.MONTHS"," month(s)"))
-		));
+			);
 
-		$f->addFieldsToTab("Root.$recursion", array (
-			new OptionsetField('MonthlyRecursionType1','', array('1' => _t('CalendarEvent.ONTHESEDATES','On these date(s)...'))),
-			new CheckboxSetField('RecurringDaysOfMonth', '', DataList::create("RecurringDayOfMonth")->map("ID", "Value")),
-			new OptionsetField('MonthlyRecursionType2','', array('1' => _t('CalendarEvent.ONTHE','On the...')))
-		));
+			$f->addFieldsToTab("Root.$recursion", array(
+				new CheckboxField('Recursion',_t('CalendarEvent.REPEATEVENT','Repeat this event')),			
+				new OptionsetField(
+					'CustomRecursionType',
+					_t('CalendarEvent.DESCRIBEINTERVAL','Describe the interval at which this event recurs.'),
+					array (
+						'1' => _t('CalendarEvent.DAILY','Daily'),
+						'2' => _t('CalendarEvent.WEEKLY','Weekly'),
+						'3' => _t('CalendarEvent.MONTHLY','Monthly')
+					)
+				)
+			));
+		
+			$f->addFieldToTab("Root.$recursion", $dailyInterval = new FieldGroup(
+						new LabelField($name = "every1", $title = _t("CalendarEvent.EVERY","Every ")),
+						new DropdownField('DailyInterval', '', array_combine(range(1,10), range(1,10))),
+						new LabelField($name = "days",$title = _t("CalendarEvent.DAYS"," day(s)"))
+			));			
+		
+			$f->addFieldToTab("Root.$recursion", $weeklyInterval = new FieldGroup(
+						new LabelField($name = "every2", $title = _t("CalendarEvent.EVERY","Every ")),
+						new DropdownField('WeeklyInterval', '', array_combine(range(1,10), range(1,10))),
+						new LabelField($name = "weeks", $title = _t("CalendarEvent.WEEKS", " weeks"))
+			));
+		
+			$f->addFieldToTab("Root.$recursion", new CheckboxSetField(
+					'RecurringDaysOfWeek', 
+					_t('CalendarEvent.ONFOLLOWINGDAYS','On the following day(s)...'), 
+					DataList::create("RecurringDayOfWeek")->map("ID", "Title")
+			));
+		
+			$f->addFieldToTab("Root.$recursion", $monthlyInterval = new FieldGroup(
+					new LabelField($name="every3", $title = _t("CalendarEvent.EVERY","Every ")),
+					new DropdownField('MonthlyInterval', '', array_combine(range(1,10), range(1,10))),
+					new LabelField($name = "months", $title = _t("CalendarEvent.MONTHS"," month(s)"))
+			));
 
-		$f->addFieldToTab("Root.$recursion", $monthlyIndex = new FieldGroup(
-				new DropdownField('MonthlyIndex','', array (
-					'1' => _t('CalendarEvent.FIRST','First'),
-					'2' => _t('CalendarEvent.SECOND','Second'),
-					'3' => _t('CalendarEvent.THIRD','Third'),
-					'4' => _t('CalendarEvent.FOURTH','Fourth'),
-					'5' => _t('CalendarEvent.LAST','Last')
-				)),
-				new DropdownField('MonthlyDayOfWeek','', DataList::create("RecurringDayOfWeek")->map("Value", "Title")),
-				new LabelField( $name = "ofthemonth", $title = _t("CalendarEvent.OFTHEMONTH"," of the month."))
-		));
-		$f->addFieldToTab("Root.$recursion",
-		 	GridField::create(
-		 		"Exceptions",
-		 		_t('CalendarEvent.ANYEXCEPTIONS','Any exceptions to this pattern? Add the dates below.'),
-		 		$this->Exceptions(),
-		 		GridFieldConfig_RecordEditor::create()
-		 	)
-		);
-		$dailyInterval->addExtraClass('dailyinterval');
-		$weeklyInterval->addExtraClass('weeklyinterval');
-		$monthlyInterval->addExtraClass('monthlyinterval');
-		$monthlyIndex->addExtraClass('monthlyindex');
+			$f->addFieldsToTab("Root.$recursion", array (
+				new OptionsetField('MonthlyRecursionType1','', array('1' => _t('CalendarEvent.ONTHESEDATES','On these date(s)...'))),
+				new CheckboxSetField('RecurringDaysOfMonth', '', DataList::create("RecurringDayOfMonth")->map("ID", "Value")),
+				new OptionsetField('MonthlyRecursionType2','', array('1' => _t('CalendarEvent.ONTHE','On the...')))
+			));
 
+			$f->addFieldToTab("Root.$recursion", $monthlyIndex = new FieldGroup(
+					new DropdownField('MonthlyIndex','', array (
+						'1' => _t('CalendarEvent.FIRST','First'),
+						'2' => _t('CalendarEvent.SECOND','Second'),
+						'3' => _t('CalendarEvent.THIRD','Third'),
+						'4' => _t('CalendarEvent.FOURTH','Fourth'),
+						'5' => _t('CalendarEvent.LAST','Last')
+					)),
+					new DropdownField('MonthlyDayOfWeek','', DataList::create("RecurringDayOfWeek")->map("Value", "Title")),
+					new LabelField( $name = "ofthemonth", $title = _t("CalendarEvent.OFTHEMONTH"," of the month."))
+			));
+			$f->addFieldToTab("Root.$recursion",
+				GridField::create(
+					"Exceptions",
+					_t('CalendarEvent.ANYEXCEPTIONS','Any exceptions to this pattern? Add the dates below.'),
+					$self->Exceptions(),
+					GridFieldConfig_RecordEditor::create()
+				)
+			);
+			$dailyInterval->addExtraClass('dailyinterval');
+			$weeklyInterval->addExtraClass('weeklyinterval');
+			$monthlyInterval->addExtraClass('monthlyinterval');
+			$monthlyIndex->addExtraClass('monthlyindex');
+
+		});
+		
+		$f = parent::getCMSFields();
+		
 		return $f;
-	
 	}
 
 	public function getRecursionReader() {

--- a/code/CalendarEvent.php
+++ b/code/CalendarEvent.php
@@ -32,8 +32,7 @@ class CalendarEvent extends Page {
 	
 	private static $can_be_root = false;
 
-	public function getCMSFields() {
-		Requirements::javascript('event_calendar/javascript/calendar_cms.js');
+	public function getCMSFields() {=
 		
 		$self = $this;
 		


### PR DESCRIPTION
so that extensions can use updateCMSFields to manipulate (remove) CMS Fields and Tabs.