### PR TITLE
Prevent html and line breaks in ICS Description.

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -742,7 +742,7 @@ class Calendar_Controller extends Page_Controller {
 				$URL = "";
 			}
 			$TITLE = $feed ? $_REQUEST['title'] : $event->Title;
-			$CONTENT = $feed ? $_REQUEST['content'] : $event->Content;
+			$CONTENT = $feed ? $_REQUEST['content'] : $event->obj('Content')->Summary();
 			$LOCATION = $feed ? $_REQUEST['location'] : $event->Location;
 			$this->getResponse()->addHeader('Cache-Control','private');
 			$this->getResponse()->addHeader('Content-Description','File Transfer');


### PR DESCRIPTION
I discovered today that line breaks in the Description prevent the ICS from downloading in Safari.
This change uses Summary to grab a (safe) snippet of the content.