### PR TITLE
Set headers correctly on RSS feed

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -661,7 +661,8 @@ class Calendar_Controller extends Page_Controller {
 		$xml = trim($xml);
 		HTTP::add_cache_headers();
 		$this->getResponse()->addHeader('Content-Type', 'application/rss+xml');
-		echo $xml;
+		$this->getResponse()->setBody($xml);
+        	return $this->getResponse();
 	}
 
 	public function monthjson(SS_HTTPRequest $r) {


### PR DESCRIPTION
In order for the headers to be set correctly, the response needs to be returned from the function rather than the raw content.