### PR TITLE
Fixing recurring event stray end date bug

### DIFF
--- a/code/CalendarEvent.php
+++ b/code/CalendarEvent.php
@@ -223,6 +223,7 @@ class CalendarEvent_Controller extends Page_Controller {
 				$datetime = $allDates->first();
 				if($datetime) {
 					$datetime->StartDate = $date;
+					$datetime->EndDate = $date;
 					return $datetime;
 				}
 			}


### PR DESCRIPTION
When viewing an instance of a recurring event the end date was incorrectly being displayed. I have updated the code to correctly set the end date for the Event CurrentDate function for these recurring date items.

I believe this fixes the front end issue #58 as originally described by Legin76.