### PR TITLE
Fixing SS_HTTPReqest typo bug in Calendar

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -624,7 +624,7 @@ class Calendar_Controller extends Page_Controller {
 	}
 
 
-	public function month(SS_HTTPReqest $r) {
+	public function month(SS_HTTPRequest $r) {
 		$this->setMonthView();
 		return $this->respond();
 	}


### PR DESCRIPTION
The `Calendar` `month` function parameter has a typo that causes calling this function to break in SilverStripe 3.2+ .