### PR TITLE
Fix [Recoverable Error] Argument 1 passed to ICSWriter::getFormatedDateTime()

### DIFF
--- a/code/ICSWriter.php
+++ b/code/ICSWriter.php
@@ -158,8 +158,8 @@ class ICSWriter
     	$this->addLine('BEGIN:VEVENT');
 		$this->addLine('UID:' . $this->getUID($dateTime) );
 		$this->addLine('DTSTAMP;TZID=' . Calendar::config()->timezone . ':' . $this->getFormatedDateTime());
-		$this->addLine('DTSTART;TZID=' . Calendar::config()->timezone . ':' . $this->getFormatedDateTime($dateTime->StartDate, $dateTime->StartTime));
-		$this->addLine('DTEND;TZID='   . Calendar::config()->timezone . ':' . $this->getFormatedDateTime($dateTime->StartDate, $dateTime->StartTime));
+		$this->addLine('DTSTART;TZID=' . Calendar::config()->timezone . ':' . $this->getFormatedDateTime(new Date($dateTime->StartDate), new Time($dateTime->StartTime)));
+		$this->addLine('DTEND;TZID='   . Calendar::config()->timezone . ':' . $this->getFormatedDateTime(new Date($dateTime->StartDate), new Time($dateTime->StartTime)));
 		$this->addLine('URL:' . Director::absoluteURL($dateTime->ICSLink()));
 		$this->addLine('SUMMARY:CHARSET=UTF-8:' . $dateTime->Event()->Title);
 		$this->addLine('END:VEVENT');

--- a/code/ICSWriter.php
+++ b/code/ICSWriter.php
@@ -158,8 +158,8 @@ class ICSWriter
     	$this->addLine('BEGIN:VEVENT');
 		$this->addLine('UID:' . $this->getUID($dateTime) );
 		$this->addLine('DTSTAMP;TZID=' . Calendar::config()->timezone . ':' . $this->getFormatedDateTime());
-		$this->addLine('DTSTART;TZID=' . Calendar::config()->timezone . ':' . $this->getFormatedDateTime(new Date($dateTime->StartDate), new Time($dateTime->StartTime)));
-		$this->addLine('DTEND;TZID='   . Calendar::config()->timezone . ':' . $this->getFormatedDateTime(new Date($dateTime->StartDate), new Time($dateTime->StartTime)));
+		$this->addLine('DTSTART;TZID=' . Calendar::config()->timezone . ':' . $this->getFormatedDateTime($dateTime->dbObject('StartDate'), $dateTime->dbObject('StartTime')));
+		$this->addLine('DTEND;TZID='   . Calendar::config()->timezone . ':' . $this->getFormatedDateTime($dateTime->dbObject('EndDate'), $dateTime->dbObject('EndTime')));
 		$this->addLine('URL:' . Director::absoluteURL($dateTime->ICSLink()));
 		$this->addLine('SUMMARY:CHARSET=UTF-8:' . $dateTime->Event()->Title);
 		$this->addLine('END:VEVENT');


### PR DESCRIPTION
BUGFIX: fixes [Recoverable Error] Argument 1 passed to ICSWriter::getFormatedDateTime() and also fixes DTEND;TZID which was using the wrong date/time.