### PR TITLE
Pass ICS Feed ID to event list

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -363,6 +363,8 @@ class Calendar extends Page {
 			foreach ( $events as $event ) {
 				// translate iCal schema into CalendarAnnouncement schema (datetime + title/content)
 				$feedevent = new CalendarAnnouncement;
+                //pass ICS feed ID to event list
+				$feedevent->ID = 'ICS_'.$feed->ID;
 				$feedevent->Title = $event['SUMMARY'];
 				if ( isset($event['DESCRIPTION']) ) {
 					$feedevent->Content = $event['DESCRIPTION'];


### PR DESCRIPTION
Pass ICS Feed ID to event list to support data extensions to ICS Feed. 

Expose ICS Feed ID in event list. Append with 'ICS_' because ICS Calendar ID is not unique for each event and could also clash with other event IDs.