### PR TITLE
fix(Calendar): Remove unnecessary Events() call in 'index'

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -602,7 +602,6 @@ class Calendar_Controller extends Page_Controller {
 
 			default:
 				$this->setDefaultView();
-				$list = $this->Events();
 				return $this->respond();
 			break;
 


### PR DESCRIPTION
fix(Calendar): Remove unnecessary Events() call in 'index'.

This was causing a 500ms to 5 second slowdown on my site with ~2000 events 
(It doesn't even utilize/touch the 'Events()' function provided)