### PR TITLE
Fix issue with Feed Events showing at 12:00

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -380,6 +380,9 @@ class Calendar extends Page {
 					|| $startdatetime > $end && $enddatetime > $end) {
 					// do nothing; dates outside range
 				} else {
+					$startdatetime = $this->iCalDateToDateTime($event['DTSTART']);
+					$enddatetime = $this->iCalDateToDateTime($event['DTEND']);
+                    
 					$feedevent->StartDate = $startdatetime->format('Y-m-d');
 					$feedevent->StartTime = $startdatetime->format('H:i:s');
 


### PR DESCRIPTION
My previous fix treated events as starting at 12:00 to fix filtering. However this had the side effect of showing events at 12:00 too. This commit fixes that oversight.