### PR TITLE
Avoid strict standards warning in Calendar_Controller::index()

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -570,7 +570,8 @@ class Calendar_Controller extends Page_Controller {
 		return array();
 	}
 
-	public function index(SS_HTTPRequest $r) {
+	public function index() {
+        $r = $this->request;
 		$this->extend('index',$r);
 		switch($this->DefaultView) {
 			case "month":


### PR DESCRIPTION
If you declare the index() function in your Page_Controller, you are forced to add "SS_HTTPRequest $r" as an argument otherwise you will encounter a Strict Standards warning. This causes issues with other modules that extend Page_Controller and do not include the request argument as they will then produce Strict Standard warnings.