### PR TITLE
FIX: prevent 00:00:00 being saved to the feed item

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -372,12 +372,14 @@ class Calendar extends Page {
 				$startdatetime = $this->iCalDateToDateTime($event['DTSTART']);//->setTimezone(new DateTimeZone($this->stat('timezone')));
 				$enddatetime = $this->iCalDateToDateTime($event['DTEND']);//->setTimezone(new DateTimeZone($this->stat('timezone')));
                 
-                //Set event start/end to midnight to allow comparisons below to work
-   				$startdatetime->modify('00:00:00');
-				$enddatetime->modify('00:00:00');
+                // Set event start/end to midnight to allow comparisons below to work
+                $comparestartdatetime = $startdatetime;
+   				$comparestartdatetime->modify('00:00:00');
+                $compareenddatetime = $enddatetime;
+				$compareenddatetime->modify('00:00:00');
                 
-				if ( ($startdatetime < $start && $enddatetime < $start)
-					|| $startdatetime > $end && $enddatetime > $end) {
+				if ( ($comparestartdatetime < $start && $compareenddatetime < $start)
+					|| $comparestartdatetime > $end && $compareenddatetime > $end) {
 					// do nothing; dates outside range
 				} else {
 					$feedevent->StartDate = $startdatetime->format('Y-m-d');


### PR DESCRIPTION
Copied the iCal feed DateTime values for Start and End to a new variable for comparison, so that the modification of 00:00:00 is not saved back to the ical feed item.  Prevents "12:00" being displayed for the start and finish time of all events in the iCal feed.

Refers to https://github.com/unclecheese/silverstripe-event-calendar/issues/141