### PR TITLE
Introducing EventDateTime

### DIFF
--- a/code/CalendarDateTime.php
+++ b/code/CalendarDateTime.php
@@ -1,79 +1,13 @@
 <?php
 
 class CalendarDateTime extends DataObject {
-	
-	private static $db = array (		
-		'StartDate' => 'Date',
-		'StartTime' => 'Time',
-		'EndDate' => 'Date',
-		'EndTime' => 'Time',
-		'AllDay' => 'Boolean'		
-	);
-	
+
 	private static $has_one = array (
 		'Event' => 'CalendarEvent'
 	);
 
-	private static $date_format_override;
-
-	private static $time_format_override;
-
-	private static $default_sort = "StartDate ASC, StartTime ASC";
-
-	/**
-	 * Set to the timezone offset (E.g. +12:00 for GMT+12). Must be in ISO 8601 format
-	 * 
-	 * @config
-	 * @see http://php.net/manual/en/function.date.php
-	 * @var string
-	 */
-	private static $offset = "+00:00";
-
-	public function getCMSFields() {
-		DateField::set_default_config('showcalendar', true);
-		$f = new FieldList(
-			new DateField('StartDate',_t('CalendarDateTime.STARTDATE','Start date')),
-			new DateField('EndDate',_t('CalendarDateTime.ENDDATE','End date')),
-			new TimeField('StartTime', _t('CalendarDateTime.STARTTIME','Start time')),
-			new TimeField('EndTime', _t('CalendarDateTime.ENDTIME','End time')),
-			new CheckboxField('AllDay', _t('CalendarDateTime.ALLDAY','This event lasts all day'))
-		);
-
-		$this->extend('updateCMSFields', $f);
-
-		return $f;
-	}
-
-	public function summaryFields() {
-		return array (
-			'FormattedStartDate' => _t('Calendar.STARTDATE','Start date'),
-			'FormattedEndDate' => _t('Calendar.ENDDATE','End date'),
-			'FormattedStartTime' => _t('Calendar.STARTTIME','Start time'),
-			'FormattedEndTime' => _t('Calendar.ENDTIME','End time'),
-			'FormattedAllDay' => _t('Calendar.ALLDAY','All day'),
-		);
-	}
-
 	public function Link() {
 		return Controller::join_links($this->Event()->Link(),"?date=".$this->StartDate);
-	}
-
-	public function DateRange() {		
-		list($strStartDate,$strEndDate) = CalendarUtil::get_date_string($this->StartDate,$this->EndDate);
-		$html =   "<span class='dtstart' title='".$this->MicroformatStart()."'>" . $strStartDate . "</span>"; 
-		$html .=	($strEndDate != "") ? "-" : "";
-		$html .= "<span class='dtend' title='" .$this->MicroformatEnd() ."'>";
-		$html .=    ($strEndDate != "") ? $strEndDate : "";
-		$html .=  "</span>";
-		
-		return $html;
-	}
-	
-	public function TimeRange() {
-		$func = CalendarUtil::get_time_format() == "24" ? "Nice24" : "Nice";
-		$ret = $this->obj('StartTime')->$func();
-		$ret .= $this->EndTime ? " &mdash; " . $this->obj('EndTime')->$func() : "";
-		return $ret;
 	}
 
 	public function Announcement() {
@@ -93,35 +27,6 @@ class CalendarDateTime extends DataObject {
 			->where("EventID = {$this->EventID}")
 			->where("StartDate != '{$this->StartDate}'")
 			->limit($this->Event()->Parent()->OtherDatesCount);
-	}
-
-	public function MicroformatStart($offset = true) {
-		if(!$this->StartDate)
-			return "";
-			
-		$date = $this->StartDate;
-	
-		if($this->AllDay)
-			$time = "00:00:00";
-		else
-			$time = $this->StartTime ? $this->StartTime : "00:00:00";
-	
-		return CalendarUtil::microformat($date, $time, self::config()->offset);
-	}
-
-	public function MicroformatEnd($offset = true) {
-		if($this->AllDay && $this->StartDate) {
-			$time = "00:00:00";
-			$end = sfDate::getInstance($this->StartDate);
-			$date = $end->tomorrow()->date();
-			unset($end);
-		}
-		else {
-			$date = $this->EndDate ? $this->EndDate : $this->StartDate;
-			$time = $this->EndTime && $this->StartTime ? $this->EndTime : (!$this->EndTime && $this->StartTime ? $this->StartTime : "00:00:00");
-		}
-
-		return CalendarUtil::microformat($date, $time, self::config()->offset);
 	}
 
 	public function ICSLink() {
@@ -156,91 +61,12 @@ class CalendarDateTime extends DataObject {
 		);
 	}
 
-	public function getFormattedStartDate() {
-	   if(!$this->StartDate) return "--";
-	   return CalendarUtil::get_date_format() == "mdy" ? $this->obj('StartDate')->Format('m-d-Y') : $this->obj('StartDate')->Format('d-m-Y');
-	}
-	
-	public function getFormattedEndDate() {
-	   if(!$this->EndDate) return "--";
-	   return CalendarUtil::get_date_format() == "mdy" ? $this->obj('EndDate')->Format('m-d-Y') : $this->obj('EndDate')->Format('d-m-Y');
-	}
-
-	public function getFormattedStartTime() {
-	   if(!$this->StartTime) return "--";
-	   return CalendarUtil::get_time_format() == "12" ? $this->obj('StartTime')->Nice() : $this->obj('StartTime')->Nice24();
-	}
-
-	public function getFormattedEndTime() {
-	   if(!$this->EndTime) return "--";
-	   return CalendarUtil::get_time_format() == "12" ? $this->obj('EndTime')->Nice() : $this->obj('EndTime')->Nice24();
-	}
-
-	public function getFormattedAllDay() {
-	   return $this->AllDay == 1 ? _t('YES','Yes') : _t('NO','No');
-	}
-
 	public function getTitle() {
 		return $this->Event()->Title;
 	}
 
 	public function getContent() {
 		return $this->Event()->Content;
-	}
-
-	public function getAllDatesInRange() {
-		$start = sfDate::getInstance($this->StartDate);
-		$end = sfDate::getInstance($this->EndDate);
-		$dates = array ();
-		do {
-			$dates[] = $start->format('Y-m-d');
-			$start->tomorrow();
-		} while($start->get() <= $end->get());
-		return $dates;
-	}
-	
-	public function canCreate($member = null) {
-		if (!$member) {
-			$member = Member::currentUser();
-		}
-		$extended = $this->extendedCan(__FUNCTION__, $member);
-		if($extended !== null) {
-			return $extended;
-		}
-		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
-	}
-
-	public function canEdit($member = null) {
-		if (!$member) {
-			$member = Member::currentUser();
-		}
-		$extended = $this->extendedCan(__FUNCTION__, $member);
-		if($extended !== null) {
-			return $extended;
-		}
-		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
-	}
-
-	public function canDelete($member = null) {
-		if (!$member) {
-			$member = Member::currentUser();
-		}
-		$extended = $this->extendedCan(__FUNCTION__, $member);
-		if($extended !== null) {
-			return $extended;
-		}
-		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
-	}
-
-	public function canView($member = null) {
-		if (!$member) {
-			$member = Member::currentUser();
-		}
-		$extended = $this->extendedCan(__FUNCTION__, $member);
-		if($extended !== null) {
-			return $extended;
-		}
-		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
 	}
 
 }

--- a/code/EventDateTime.php
+++ b/code/EventDateTime.php
@@ -1,0 +1,181 @@
+<?php
+
+
+class EventDateTime extends DataObject {
+	
+	private static $db = array (		
+		'StartDate' => 'Date',
+		'StartTime' => 'Time',
+		'EndDate' => 'Date',
+		'EndTime' => 'Time',
+		'AllDay' => 'Boolean'
+	);
+
+	private static $date_format_override;
+
+	private static $time_format_override;
+
+	private static $default_sort = "StartDate ASC, StartTime ASC";
+
+	/**
+	 * Set to the timezone offset (E.g. +12:00 for GMT+12). Must be in ISO 8601 format
+	 * 
+	 * @config
+	 * @see http://php.net/manual/en/function.date.php
+	 * @var string
+	 */
+	private static $offset = "+00:00";
+
+	public function summaryFields() {
+		return array (
+			'FormattedStartDate' => _t('Calendar.STARTDATE','Start date'),
+			'FormattedEndDate' => _t('Calendar.ENDDATE','End date'),
+			'FormattedStartTime' => _t('Calendar.STARTTIME','Start time'),
+			'FormattedEndTime' => _t('Calendar.ENDTIME','End time'),
+			'FormattedAllDay' => _t('Calendar.ALLDAY','All day'),
+		);
+	}
+
+
+	public function getCMSFields() {
+		DateField::set_default_config('showcalendar', true);
+		$f = new FieldList(
+			new DateField('StartDate',_t('CalendarDateTime.STARTDATE','Start date')),
+			new DateField('EndDate',_t('CalendarDateTime.ENDDATE','End date')),
+			new TimeField('StartTime', _t('CalendarDateTime.STARTTIME','Start time')),
+			new TimeField('EndTime', _t('CalendarDateTime.ENDTIME','End time')),
+			new CheckboxField('AllDay', _t('CalendarDateTime.ALLDAY','This event lasts all day'))
+		);
+
+		$this->extend('updateCMSFields', $f);
+
+		return $f;
+	}
+
+	public function DateRange() {		
+		list($strStartDate,$strEndDate) = CalendarUtil::get_date_string($this->StartDate,$this->EndDate);
+		$html =   "<span class='dtstart' title='".$this->MicroformatStart()."'>" . $strStartDate . "</span>"; 
+		$html .=	($strEndDate != "") ? "-" : "";
+		$html .= "<span class='dtend' title='" .$this->MicroformatEnd() ."'>";
+		$html .=    ($strEndDate != "") ? $strEndDate : "";
+		$html .=  "</span>";
+		
+		return $html;
+	}
+	
+	public function TimeRange() {
+		$func = CalendarUtil::get_time_format() == "24" ? "Nice24" : "Nice";
+		$ret = $this->obj('StartTime')->$func();
+		$ret .= $this->EndTime ? " &mdash; " . $this->obj('EndTime')->$func() : "";
+		return $ret;
+	}
+
+	public function MicroformatStart($offset = true) {
+		if(!$this->StartDate)
+			return "";
+			
+		$date = $this->StartDate;
+	
+		if($this->AllDay)
+			$time = "00:00:00";
+		else
+			$time = $this->StartTime ? $this->StartTime : "00:00:00";
+	
+		return CalendarUtil::microformat($date, $time, self::config()->offset);
+	}
+
+	public function MicroformatEnd($offset = true) {
+		if($this->AllDay && $this->StartDate) {
+			$time = "00:00:00";
+			$end = sfDate::getInstance($this->StartDate);
+			$date = $end->tomorrow()->date();
+			unset($end);
+		}
+		else {
+			$date = $this->EndDate ? $this->EndDate : $this->StartDate;
+			$time = $this->EndTime && $this->StartTime ? $this->EndTime : (!$this->EndTime && $this->StartTime ? $this->StartTime : "00:00:00");
+		}
+
+		return CalendarUtil::microformat($date, $time, self::config()->offset);
+	}
+
+	public function getFormattedStartDate() {
+	   if(!$this->StartDate) return "--";
+	   return CalendarUtil::get_date_format() == "mdy" ? $this->obj('StartDate')->Format('m-d-Y') : $this->obj('StartDate')->Format('d-m-Y');
+	}
+	
+	public function getFormattedEndDate() {
+	   if(!$this->EndDate) return "--";
+	   return CalendarUtil::get_date_format() == "mdy" ? $this->obj('EndDate')->Format('m-d-Y') : $this->obj('EndDate')->Format('d-m-Y');
+	}
+
+	public function getFormattedStartTime() {
+	   if(!$this->StartTime) return "--";
+	   return CalendarUtil::get_time_format() == "12" ? $this->obj('StartTime')->Nice() : $this->obj('StartTime')->Nice24();
+	}
+
+	public function getFormattedEndTime() {
+	   if(!$this->EndTime) return "--";
+	   return CalendarUtil::get_time_format() == "12" ? $this->obj('EndTime')->Nice() : $this->obj('EndTime')->Nice24();
+	}
+
+	public function getFormattedAllDay() {
+	   return $this->AllDay == 1 ? _t('YES','Yes') : _t('NO','No');
+	}
+
+	public function getAllDatesInRange() {
+		$start = sfDate::getInstance($this->StartDate);
+		$end = sfDate::getInstance($this->EndDate);
+		$dates = array ();
+		do {
+			$dates[] = $start->format('Y-m-d');
+			$start->tomorrow();
+		} while($start->get() <= $end->get());
+		return $dates;
+	}
+	
+	public function canCreate($member = null) {
+		if (!$member) {
+			$member = Member::currentUser();
+		}
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
+		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+	}
+
+	public function canEdit($member = null) {
+		if (!$member) {
+			$member = Member::currentUser();
+		}
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
+		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+	}
+
+	public function canDelete($member = null) {
+		if (!$member) {
+			$member = Member::currentUser();
+		}
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
+		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+	}
+
+	public function canView($member = null) {
+		if (!$member) {
+			$member = Member::currentUser();
+		}
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
+		return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+	}
+
+}

--- a/code/EventDateTimeTask.php
+++ b/code/EventDateTimeTask.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ *
+ * Migration script to assists with upgrade
+ *  Change: CalendarDateTime extends (introduced super) EventDateTime
+ * Procedure
+ *   Move $db MySQL table fields/columns from from CalendarDateTime to EventDateTime
+ *
+ * undo (?undo=1); tables are backed-up to *_backup in the process
+ *
+ * @package EventCalendar
+ * @author	OliverBanjo
+ */
+
+class EventDateTimeTask extends MigrationTask {
+
+    protected $title = "CalendarDateTime to EventDateTime table fields migration";
+    protected $description = "Update MySQL database to reflect change in class model. Introducing base class EventDateTime, migrating date & time fields from CalendarDateTime which now extends EventDateTime";
+
+    public function run($request)
+    {
+        $new = "EventDateTime";
+        $original = "CalendarDateTime";
+        $backupPostfix = "_backup";
+
+        if($request->getVar('undo')) $this->restoreTables(array($original, $new), $backupPostfix);
+        else $this->amendTables($new, $original, $backupPostfix);
+
+    }
+
+
+
+    private function amendTables($newBaseClass, $original, $backupPostfix)
+    {
+        $backup = $original . $backupPostfix;
+        $newBaseTableBackup = $newBaseClass . $backupPostfix;	//incase user has already populated!
+
+        //check can proceed to backup
+        if ($this->tableExists($backup)) {
+            echo "Cannot execute task. $backup already exists. Remove or rename!";
+            return;
+        }
+
+        if ($this->tableExists($newBaseTableBackup)) {
+            echo "Cannot execute task. $newBaseTableBackup already exists. Remove or rename!";
+            return;
+        }
+
+
+        //select specific fields to copy
+        $obj = $newBaseClass::create();
+        $migrationFields = array_merge(
+            array('ID' => true),
+            $obj->database_fields($newBaseClass)
+        );
+
+
+        //check the CalendarDateTime expected fields (to move & remove) exist before proceeding
+        $columns = DB::query("SHOW COLUMNS FROM $original")->column();
+
+
+        if (!$this->anyFieldsExist($migrationFields, $columns)) {
+            //fields already removed
+            echo "Task already ran!";
+            return;
+        }
+
+
+        //create backups of the tables before operating
+        $this->copyTable($original, $backup);
+        echo "Table $original backed-up to $backup <br />";
+
+        $this->copyTable($newBaseClass, $newBaseTableBackup);
+        echo "Table $newBaseClass backed-up to $newBaseTableBackup <br />";
+
+
+        //copy specific fields from records to $newBaseClass
+        echo "Populating new table $newBaseClass <br />";
+        $migrationFieldsStr = implode(", ", array_keys($migrationFields));
+        DB::query("INSERT $newBaseClass SELECT $migrationFieldsStr FROM $original");
+
+
+        //remove the columns that have been moved to the new base class
+        foreach ($columns as $column) {
+            if ($column === 'ID') continue;
+            elseif (isset($migrationFields[$column])) $this->removeColumn($original, $column);
+                //remove unwanted columns from $original
+
+        }
+
+        echo "Task complete! <br />?undo=1 to restore tables";
+
+    }
+
+
+
+    private function anyFieldsExist($fields, $columns)
+    {
+        foreach ($columns as $column) {
+            if ($column === 'ID') continue;
+            elseif (isset($fields[$column])) return true;
+        }
+		return false;
+    }
+
+
+
+    private function tableExists($table)
+    {
+        $tableExists = DB::query("SHOW TABLES LIKE '$table'")->value();
+        if ($tableExists != null) return true;
+        return false;
+    }
+
+
+
+    private function copyTable($original, $destination)
+    {
+        echo "Creating $destination <br />";
+        DB::query("CREATE TABLE $destination LIKE $original");
+        DB::query("INSERT $destination SELECT * FROM $original");
+    }
+
+
+
+    private function removeTable($table)
+    {
+        echo "Removing table $table <br />";
+        DB::query("DROP TABLE $table");
+    }
+
+
+
+    private function removeColumn($table, $column)
+    {
+        echo "Dropping $column from $table <br />";
+        DB::query("ALTER TABLE $table DROP COLUMN $column");
+    }
+
+
+
+    private function restoreTables($tables, $backupPostfix)
+    {
+        foreach ($tables as $table) {
+            $backup = $table . $backupPostfix;
+            if ($this->tableExists($backup)) {
+                echo "Restoring $table <br />";
+                //remove existing (unwanted) table & replace with the backup
+                if ($this->tableExists($table)) $this->removeTable($table);
+                $this->copyTable($backup, $table);
+                $this->removeTable($backup);	//delete old backup
+            }
+            else echo "Cannot restore $table,  $backup does not exist.<br />";
+        }
+
+        echo "Tables restored.";
+    }
+
+
+}


### PR DESCRIPTION
This would be a first step as an example to dividing the CalendarDateTime class for interoperability and reusability, to align with SS4 principles.

Introducing new super class EventDateTime . See unclecheese/silverstripe-event-calendar  issue 140.

Time & date specific fields ($db properties) and reusable functionality tied to those properties moved to EventDateTime. ie CalendarDateTime methods with reference to Event() or that are relevant to CalendarAnnouncement remain.

Have included a reversible migration task to assist with moving table fields to the new intermediary tier.