### PR TITLE
Ensure compatibility with SS 3.7 & PHP 7.2

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -17,3 +17,9 @@ $customDateTemplates = array(
 
 */
 );
+
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/RecursionReader.php
+++ b/code/RecursionReader.php
@@ -1,6 +1,6 @@
 <?php
 
-class RecursionReader extends Object {
+class RecursionReader extends SS_Object {
 	
 	const DAY = 86400;
 
@@ -19,6 +19,8 @@ class RecursionReader extends Object {
 	}
 
 	public function __construct(CalendarEvent $event) {
+	    parent::__construct();
+
 		$this->event = $event;
 		$this->datetimeClass = $event->Parent()->getDateTimeClass();
 		$this->eventClass = $event->Parent()->getEventClass();


### PR DESCRIPTION
This fixes the SS 3.7+ & PHP 7.2 compatibility, effectively renaming calls to Object:: to SS_Object:: and aliasing SS_Object to Object for backwards compatibility (older versions of SilverStripe) [as described here](https://docs.silverstripe.org/en/3/changelogs/3.7.0/#for-module-authors).

If you could also make this a tagged release please after merge that would be great.