### PR TITLE
Fixed a typo of the variable name: data_obj -> dataObj

### DIFF
--- a/src/Pages/CalendarEventController.php
+++ b/src/Pages/CalendarEventController.php
@@ -60,7 +60,7 @@ class CalendarEventController extends PageController
 	{
 		if (!isset($_REQUEST['date'])) {
 			$dateObj =  $this->DateAndTime()->first();
-			if (!$date_obj) {
+			if (!$dateObj) {
 				return false;
 			}
 			$date = $dateObj->StartDate;


### PR DESCRIPTION
Typo of the variable name.