### PR TITLE
Update RecurringException.php

### DIFF
--- a/code/RecurringException.php
+++ b/code/RecurringException.php
@@ -33,7 +33,7 @@ class RecurringException extends DataObject {
 
     public function getFormattedExceptionDate() {
        if(!$this->ExceptionDate) return "--";
-       return CalendarUtil::get_date_format() == "mdy" ? $this->obj('ExceptionDate')->Format('m-d-Y') : $this->obj('ExceptionDate')->Format('d-m-Y');
+       return CalendarUtil::get_date_format() == "mdy" ? $this->obj('ExceptionDate')->Format('MM-dd-Y') : $this->obj('ExceptionDate')->Format('dd-MM-Y');
     }
 
 


### PR DESCRIPTION
Bug fix for exception date formatting in the CMS. The original code assumes the formatting is using php date conventions, however its not, its using the Silverstripe formatting so is current displaying incorrectly.